### PR TITLE
Improved Gradle dependency-check default data directory for version 5.1.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,12 +129,12 @@ Configuration examples (using default directories):
 dependencyCheck {
     data {
         // must correspond with CircleCI-configuration
-        directory = System.properties['user.home'] + "/.gradle/caches/dependency-check-data" 
+        directory = System.properties['user.home'] + "/.gradle/dependency-check-data" 
     }
 }
 ```
 
-for `cve_data_directory` parameter value `~/.gradle/caches/dependency-check-data`.
+for `cve_data_directory` parameter value `~/.gradle/dependency-check-data`.
 
 #### Maven 
 

--- a/README.md
+++ b/README.md
@@ -119,7 +119,7 @@ The OWASP plugin checks for updates to its database every four hours, and the da
 So for each working day, the first builds (in the morning) will check for updates, and last for four hours with potential cache refreshes every four clock hours (at 9, 13, 17, 21 and so on). In other words, the OWASP plugin will check for updates whenever four hours have passed, and will be able to persist those updates to CircleCI cache in maximum four hours - a compromise between time spent saving cache and time spent checking for updates.
 
 ### Data directory
-Use the Orb parameter `cve_data_directory` to configure non-standard data directory. Note that for Gradle builds this is necessary for plugin version <= `5.1.0`.
+Use the orb parameter `cve_data_directory` to configure non-standard data directory. Note that for Gradle builds this is necessary for plugin version <= `5.1.0`.
 
 Configuration examples (using default directories):
 
@@ -128,7 +128,8 @@ Configuration examples (using default directories):
 ```
 dependencyCheck {
     data {
-        directory = System.properties['user.home'] + "/.gradle/caches/dependency-check-data" // must correspond with CircleCI-configuration
+        // must correspond with CircleCI-configuration
+        directory = System.properties['user.home'] + "/.gradle/caches/dependency-check-data" 
     }
 }
 ```

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Import the orb
 
 ```yaml
 orbs:
-  owasp: entur/owasp@0.0.3
+  owasp: entur/owasp@0.0.4
 ```
 
 ## Gradle
@@ -27,7 +27,7 @@ Then add [OWASP Gradle Plugin](https://github.com/jeremylong/DependencyCheck) to
 
 ```groovy
 plugins {
-    id 'org.owasp.dependencycheck' version '5.1.0'
+    id 'org.owasp.dependencycheck' version '5.1.1'
 }
 
 dependencyCheck {
@@ -35,15 +35,8 @@ dependencyCheck {
     format = 'ALL' // CI-tools usually needs XML-reports, but humans needs HTML.
     failBuildOnCVSS = 7 // Specifies if the build should be failed if a CVSS score equal to or above a specified level is identified.
     suppressionFiles = ["$projectDir/dependencycheck-base-suppression.xml"] // specify a list of known issues which contain false-positives
-
-    data {
-        directory = System.properties['user.home'] + "/.owasp-dependency-check" // must correspond with CircleCI-configuration
-    }
 }
 ```
-
-where the data directory __must correspond__ to the orb job parameter `cve_data_directory` (default value is `~/.owasp-dependency-check` like in the configuration above).
-
 
 #### Details
 The default OWASP plugin task is `dependencyCheckAnalyze`, for using other tasks, add a `task` parameter as so:
@@ -112,17 +105,6 @@ workflows:
           task: aggregate
 ```
 
-If the data directory is specified, 
-
-```xml
-<configuration>
-    <dataDirectory>${user.home}/.m2/repository/org/owasp/dependency-check-data</dataDirectory>
-</configuration>
-```
-
-it __must correspond__ to the orb job parameter `cve_data_directory` (default value is `~/.m2/repository/org/owasp/dependency-check-data` corresponding to the above configuration). 
-
-
 ## Caching
 The OWASP plugin checks for updates to its database every four hours, and the database is cached by the orb like so:
 
@@ -135,5 +117,33 @@ The OWASP plugin checks for updates to its database every four hours, and the da
  * 4 hours
 
 So for each working day, the first builds (in the morning) will check for updates, and last for four hours with potential cache refreshes every four clock hours (at 9, 13, 17, 21 and so on). In other words, the OWASP plugin will check for updates whenever four hours have passed, and will be able to persist those updates to CircleCI cache in maximum four hours - a compromise between time spent saving cache and time spent checking for updates.
+
+### Data directory
+Use the Orb parameter `cve_data_directory` to configure non-standard data directory. Note that for Gradle builds this is necessary for plugin version <= `5.1.0`.
+
+Configuration examples (using default directories):
+
+#### Gradle
+
+```
+dependencyCheck {
+    data {
+        directory = System.properties['user.home'] + "/.gradle/caches/dependency-check-data" // must correspond with CircleCI-configuration
+    }
+}
+```
+
+for `cve_data_directory` parameter value `~/.gradle/caches/dependency-check-data`.
+
+#### Maven 
+
+```xml
+<configuration>
+    <!-- must correspond with CircleCI-configuration -->
+    <dataDirectory>${user.home}/.m2/repository/org/owasp/dependency-check-data</dataDirectory>
+</configuration>
+```
+
+for `cve_data_directory` parameter value `~/.m2/repository/org/owasp/dependency-check-data`.
 
 See the [orb](/src/@orb.yml) source or [CircleCI orb registry](https://circleci.com/orbs/registry/orb/entur/owasp) for further details.

--- a/src/@orb.yml
+++ b/src/@orb.yml
@@ -84,7 +84,7 @@ aliases:
       - gradle/with_cache:
           steps:
             - generate_cache_keys:
-                cache_key: gradle-<< parameters.cache_key >>-cache-key-v5
+                cache_key: gradle-<< parameters.cache_key >>-cache-key-v6
             - restore_owasp_cache
             - run:
                 name: Update OWASP Dependency Check Database.
@@ -210,7 +210,7 @@ jobs:
           settings_file: << parameters.settings_file >>
           steps:
             - generate_cache_keys:
-                cache_key: maven-<< parameters.cache_key >>-cache-key-v5
+                cache_key: maven-<< parameters.cache_key >>-cache-key-v6
             - restore_owasp_cache
             - run:
                 name: Update OWASP Dependency Check Database.

--- a/src/@orb.yml
+++ b/src/@orb.yml
@@ -63,7 +63,7 @@ aliases:
         type: string
         default: "~/.gradle/dependency-check-data"
       task:
-        description: Task name
+        description: Task name.
         type: string
         default: "dependencyCheckAnalyze"
       report_path:
@@ -87,13 +87,13 @@ aliases:
                 cache_key: gradle-<< parameters.cache_key >>-cache-key-v6
             - restore_owasp_cache
             - run:
-                name: Update OWASP Dependency Check Database.
+                name: Update OWASP Dependency Check Database
                 command: ./gradlew dependencyCheckUpdate --info
             - store_owasp_cache:
                 cve_data_directory: <<parameters.cve_data_directory>>
             - run:
                 # note: Also run purge so so that vulernability data is not cached twice
-                name: Run OWASP Dependency Check Analyzer.
+                name: Run OWASP Dependency Check Analyzer
                 command: ./gradlew <<parameters.task>> dependencyCheckPurge --info
             - collect_reports:
                 reports_path: <<parameters.report_path>>
@@ -103,7 +103,7 @@ commands:
   restore_owasp_cache:
     steps:
       - restore_cache:
-          name: Restore OWASP Dependency Check Database from CircleCI cache.
+          name: Restore OWASP Dependency Check Database from CircleCI cache
           keys:
             - cve-cache-{{ checksum "/tmp/key" }}-{{ checksum "/tmp/year" }}-{{ checksum "/tmp/twelveWeeks" }}-{{ checksum "/tmp/fourWeeks" }}-{{ checksum "/tmp/week" }}-{{ checksum "/tmp/day" }}-{{ checksum "/tmp/twelveHoursOfDay" }}-{{ checksum "/tmp/fourHoursOfDay" }}
             - cve-cache-{{ checksum "/tmp/key" }}-{{ checksum "/tmp/year" }}-{{ checksum "/tmp/twelveWeeks" }}-{{ checksum "/tmp/fourWeeks" }}-{{ checksum "/tmp/week" }}-{{ checksum "/tmp/day" }}-{{ checksum "/tmp/twelveHoursOfDay" }}
@@ -119,7 +119,7 @@ commands:
         type: string
     steps:
       - save_cache:
-          name: Save OWASP Dependency Check Database to CircleCI cache.
+          name: Save OWASP Dependency Check Database to CircleCI cache
           key: cve-cache-{{ checksum "/tmp/key" }}-{{ checksum "/tmp/year" }}-{{ checksum "/tmp/twelveWeeks" }}-{{ checksum "/tmp/fourWeeks" }}-{{ checksum "/tmp/week" }}-{{ checksum "/tmp/day" }}-{{ checksum "/tmp/twelveHoursOfDay" }}-{{ checksum "/tmp/fourHoursOfDay" }}
           paths:
             - <<parameters.cve_data_directory>>
@@ -131,7 +131,7 @@ commands:
         type: string
     steps:
       - run:
-          name: Generate OWASP Dependency Check Database CircleCI cache keys.
+          name: Generate OWASP Dependency Check Database CircleCI cache keys
           command: |
             echo <<parameters.cache_key>> >> /tmp/key
             echo $(date +"%Y") >> /tmp/year
@@ -153,19 +153,19 @@ commands:
         type: boolean
     steps:
       - run:
-          name: Extract OWASP Dependency Check reports.
+          name: Extract OWASP Dependency Check reports
           command: |
             mkdir -p Reports/OWASP
             cp << parameters.reports_path >>/dependency-check*.* Reports/OWASP
       - store_artifacts:
-          name: Store OWASP Dependency Check reports as artifacts (in 'Reports/OWASP' directory).
+          name: Store OWASP Dependency Check reports as artifacts (in 'Reports/OWASP' directory)
           path: Reports/OWASP
           destination: Reports/OWASP
       - when:
           condition: <<parameters.persist_to_workspace>>
           steps:
             - persist_to_workspace:
-                name: Persist OWASP Dependency Check reports to workspace (in 'Reports/OWASP' directory).
+                name: Persist OWASP Dependency Check reports to workspace (in 'Reports/OWASP' directory)
                 root: .
                 paths:
                   - Reports/OWASP
@@ -184,7 +184,7 @@ jobs:
         type: string
         default: "~/.m2/repository/org/owasp/dependency-check-data"
       task:
-        description: Task name
+        description: Task name.
         type: string
         default: "check"
       report_path:
@@ -213,13 +213,13 @@ jobs:
                 cache_key: maven-<< parameters.cache_key >>-cache-key-v6
             - restore_owasp_cache
             - run:
-                name: Update OWASP Dependency Check Database.
+                name: Update OWASP Dependency Check Database
                 command: mvn org.owasp:dependency-check-maven:update-only
             - store_owasp_cache:
                 cve_data_directory: <<parameters.cve_data_directory>>
             - run:
                 # note: Also run purge so so that vulernability data is not cached twice (which it will by default, as it is stored within the .m2 directory)
-                name: Run OWASP Dependency Check Analyzer.
+                name: Run OWASP Dependency Check Analyzer
                 command: mvn org.owasp:dependency-check-maven:<<parameters.task>> org.owasp:dependency-check-maven:purge
             - collect_reports:
                 reports_path: <<parameters.report_path>>

--- a/src/@orb.yml
+++ b/src/@orb.yml
@@ -61,7 +61,7 @@ aliases:
       cve_data_directory:
         description: The plugin database directory.
         type: string
-        default: "~/.gradle/caches/dependency-check-data"
+        default: "~/.gradle/dependency-check-data"
       task:
         description: Task name
         type: string

--- a/src/@orb.yml
+++ b/src/@orb.yml
@@ -84,7 +84,7 @@ aliases:
       - gradle/with_cache:
           steps:
             - generate_cache_keys:
-                cache_key: gradle-<< parameters.cache_key >>-cache-key-v4
+                cache_key: gradle-<< parameters.cache_key >>-cache-key-v5
             - restore_owasp_cache
             - run:
                 name: Update OWASP Dependency Check Database.
@@ -210,7 +210,7 @@ jobs:
           settings_file: << parameters.settings_file >>
           steps:
             - generate_cache_keys:
-                cache_key: maven-<< parameters.cache_key >>-cache-key-v4
+                cache_key: maven-<< parameters.cache_key >>-cache-key-v5
             - restore_owasp_cache
             - run:
                 name: Update OWASP Dependency Check Database.

--- a/src/@orb.yml
+++ b/src/@orb.yml
@@ -61,7 +61,7 @@ aliases:
       cve_data_directory:
         description: The plugin database directory.
         type: string
-        default: "~/.owasp-dependency-check"
+        default: "~/.gradle/caches/dependency-check-data"
       task:
         description: Task name
         type: string


### PR DESCRIPTION
As there is now a [determininistic default location](https://github.com/jeremylong/dependency-check-gradle/blob/master/src/main/groovy/org/owasp/dependencycheck/gradle/extension/DataExtension.groovy#L29) for data directory for owasp dependency check plugin, update the orb correspondingly.