### PR TITLE
Fix check for directory using tilde

### DIFF
--- a/src/@orb.yml
+++ b/src/@orb.yml
@@ -242,7 +242,7 @@ commands:
           command: |
             version=$(cat /tmp/owasp_commandline_version)
             executable_url_with_version=${executable_url//VERSION/$version}
-            if [ -d "~/.owasp/dependency-check" ]
+            if [ -d ~/.owasp/dependency-check ]
             then
                 echo "Dependency-Check command-line tool version $version from $executable_url_with_version already cached."
             else


### PR DESCRIPTION
Tilde in quotes does not work..

https://serverfault.com/questions/417252/check-if-directory-exists-using-home-character-in-bash-fails