### PR TITLE
Extract commands from jobs

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ Then add [OWASP Gradle Plugin](https://github.com/jeremylong/DependencyCheck) to
 
 ```groovy
 plugins {
-    id 'org.owasp.dependencycheck' version '6.2.2'
+    id 'org.owasp.dependencycheck' version '6.5.1'
 }
 
 dependencyCheck {
@@ -84,7 +84,7 @@ Then add [OWASP Maven Plugin](https://jeremylong.github.io/DependencyCheck/depen
 <plugin>
     <groupId>org.owasp</groupId>
     <artifactId>dependency-check-maven</artifactId>
-    <version>6.2.2</version>
+    <version>6.5.1</version>
     <configuration>
         <format>all</format>
         <failBuildOnCVSS>7</failBuildOnCVSS>

--- a/README.md
+++ b/README.md
@@ -63,6 +63,8 @@ workflows:
 
 where task is one of [dependencyCheckAnalyze](https://jeremylong.github.io/DependencyCheck/dependency-check-gradle/configuration.html), [dependencyCheckAggregate](https://jeremylong.github.io/DependencyCheck/dependency-check-gradle/configuration-aggregate.html), [dependencyCheckUpdate](https://jeremylong.github.io/DependencyCheck/dependency-check-gradle/configuration-update.html), and [dependencyCheckPurge](https://jeremylong.github.io/DependencyCheck/dependency-check-gradle/configuration-purge.html).
 
+Alternatively, use the `wrapped_gradle_steps` command to customize further.
+
 ## Maven 
 Configure a job
 
@@ -95,7 +97,6 @@ Then add [OWASP Maven Plugin](https://jeremylong.github.io/DependencyCheck/depen
         </execution>
     </executions>
 </plugin>
-
 ```
 
 #### Details
@@ -112,6 +113,24 @@ workflows:
           task: aggregate
           context: global
 ```
+
+#### Maven multi-module projects
+The dependency plugin currently is not able to resolve artifacts before they are built. If internal submodule dependencies cannot reached in the build, add a few `wrapped_pre_steps` to do so.
+
+```yaml
+workflows:
+  version: 2.1
+  build:
+    jobs:
+      - owasp/maven_owasp_dependency_check:
+          executor: java_11
+          context: global
+          wrapped_pre_steps:
+            - run:  mvn install -Dmaven.test.skip=true
+```
+
+Alternatively, use the `wrapped_maven_steps` command to customize further.
+
 
 ## Command Line Tool
 Configure a job

--- a/src/@orb.yml
+++ b/src/@orb.yml
@@ -59,19 +59,26 @@ examples:
 
 orbs:
   gradle: circleci/gradle@2.2.0
-  maven: circleci/maven@1.0.3
-
+  maven: circleci/maven@1.2.0
 
 executors:
   default:
+    description: |
+       This default Docker image is highly cached on CircleCI and contains most necessary tools needed for Gradle related projects.
     docker:
-      - image: cimg/openjdk:11.0.6
+      - image: cimg/openjdk:<<parameters.tag>>
         # NB! Add $DOCKERHUB_LOGIN and $DOCKERHUB_PASSWORD credentials in your context to log in to Docker hub
         auth:
           username: $DOCKERHUB_LOGIN
           password: $DOCKERHUB_PASSWORD
         environment:
           TERM: dumb
+    parameters:
+      tag:
+        default: "11.0.13"
+        description: |
+          Pick a specific cimg/openjdk image tag: https://hub.docker.com/r/cimg/openjdk/tags
+        type: string
 
 aliases:
   - &gradle_owasp_dependency_check
@@ -99,28 +106,15 @@ aliases:
     executor: <<parameters.executor>>
     steps:
       - checkout
-      - gradle/with_cache:
+      - wrapped_gradle_steps:
+          cve_data_directory: <<parameters.cve_data_directory>>
+          settings_file: <<parameters.settings_file>>
+          cache_key: <<parameters.cache_key>>
+          persist_to_workspace: <<parameters.persist_to_workspace>>
           steps:
-            - generate_cache_keys:
-                cache_key: gradle-<< parameters.cache_key >>-cache-key
-            - restore_owasp_cache:
-                cache_key: << parameters.cache_key >>
-            - run:
-                name: Update OWASP Dependency-Check Database
-                command: ./gradlew dependencyCheckUpdate --info
-            - store_owasp_cache:
-                cve_data_directory: <<parameters.cve_data_directory>>
-                cache_key: << parameters.cache_key >>
             - run:
                 name: Run OWASP Dependency-Check Analyzer
                 command: ./gradlew <<parameters.task>> --info
-            - run:
-                # note: Also run purge so so that vulernability data is not cached twice.
-                # Run in seperate step so not run for each submodule.
-                name: OWASP Dependency-Check cache cleanup
-                command: ./gradlew dependencyCheckPurge --info
-            - collect_reports:
-                persist_to_workspace: <<parameters.persist_to_workspace>>
 
 commands:
   restore_owasp_cache:
@@ -218,6 +212,107 @@ commands:
                 root: .
                 paths:
                   - Reports/OWASP
+
+  wrapped_maven_steps:
+    description: |
+      Run a set of steps with the OWASP database updated and cached using Maven
+    parameters:
+      cve_data_directory:
+        description: The plugin database directory.
+        type: string
+        default: "~/.m2/repository/org/owasp/dependency-check-data"
+      settings_file:
+        description: Specify a custom settings file to use (optional).
+        type: string
+        default: ""
+      cache_key:
+        description: Specify a custom cache key.
+        type: string
+        default: "v1"
+      persist_to_workspace:
+        description: Persist reports to workspace for further processing.
+        type: boolean
+        default: false
+      pre_steps:
+        description: Pre-processing steps to run in order to prepare the dependency check. Intended for multi-module builds (which require build before dependency check)
+        type: steps
+      steps:
+        type: steps
+        description: Steps to run in order to perform the dependency check
+    steps:
+      - checkout
+      - maven/with_cache:
+          cache_key: << parameters.cache_key >>
+          settings_file: << parameters.settings_file >>
+          verify_dependencies: false
+          steps:
+            - generate_cache_keys:  # for both restore and store
+                cache_key: maven-<< parameters.cache_key >>-cache-key  # flow-specific key
+            - restore_owasp_cache:
+                cache_key: << parameters.cache_key >>
+            - run:
+                name: Update OWASP Dependency-Check Database
+                command: mvn org.owasp:dependency-check-maven:update-only
+            - store_owasp_cache:
+                cve_data_directory: <<parameters.cve_data_directory>>
+                cache_key: << parameters.cache_key >>
+            - steps: << parameters.pre_steps >>
+            - steps: << parameters.steps >>
+            - run:
+                # note: Also run purge so so that vulernability data is not cached twice.
+                # Run in seperate step so not run for each submodule.
+                name: OWASP Dependency-Check cache cleanup
+                command: mvn org.owasp:dependency-check-maven:purge
+            - collect_reports:
+                persist_to_workspace: <<parameters.persist_to_workspace>>
+
+  wrapped_gradle_steps:
+    description: |
+      Run a set of steps with the OWASP database updated and cached using Gradle
+    parameters:
+      cve_data_directory:
+        description: The plugin database directory.
+        type: string
+        default: "~/.gradle/dependency-check-data"
+      cache_key:
+        description: Specify a custom cache key.
+        type: string
+        default: "v1"
+      persist_to_workspace:
+        description: Persist reports to workspace for further processing.
+        type: boolean
+        default: false
+      pre_steps:
+        description: Pre-processing steps to run in order to prepare the dependency check
+        type: steps
+      steps:
+        description: Steps to run in order to perform the dependency check
+        type: steps
+    steps:
+      - checkout
+      - gradle/with_cache:
+          cache_key: << parameters.cache_key >>
+          steps:
+            - generate_cache_keys:  # for both restore and store
+                cache_key: gradle-<< parameters.cache_key >>-cache-key  # flow-specific key
+            - restore_owasp_cache:
+                cache_key: << parameters.cache_key >>
+            - run:
+                name: Update OWASP Dependency-Check Database
+                command: ./gradlew dependencyCheckUpdate --info
+            - store_owasp_cache:
+                cve_data_directory: <<parameters.cve_data_directory>>
+                cache_key: << parameters.cache_key >>
+            - steps: << parameters.pre_steps >>
+            - steps: << parameters.steps >>
+            - run:
+                # note: Also run purge so so that vulernability data is not cached twice.
+                # Run in seperate step so not run for each submodule.
+                name: OWASP Dependency-Check cache cleanup
+                command: ./gradlew dependencyCheckPurge --info
+            - collect_reports:
+                persist_to_workspace: <<parameters.persist_to_workspace>>
+
   with_commandline:
     description: |
       Run a set of steps with the OWASP Dependency-Check command-line tool. Run from ~/.owasp/dependency-check/bin/dependency-check.sh.
@@ -276,7 +371,7 @@ commands:
       - steps: << parameters.steps >>
 
 jobs:
-  owasp_dependency_check: *gradle_owasp_dependency_check # default to gradle
+  owasp_dependency_check: *gradle_owasp_dependency_check  # default to gradle
   gradle_owasp_dependency_check: *gradle_owasp_dependency_check
   maven_owasp_dependency_check:
     parameters:
@@ -307,29 +402,16 @@ jobs:
     executor: <<parameters.executor>>
     steps:
       - checkout
-      - maven/with_cache:
-          settings_file: << parameters.settings_file >>
+      - wrapped_maven_steps:
+          cve_data_directory: <<parameters.cve_data_directory>>
+          settings_file: <<parameters.settings_file>>
+          cache_key: <<parameters.cache_key>>
+          persist_to_workspace: <<parameters.persist_to_workspace>>
           steps:
-            - generate_cache_keys:
-                cache_key: maven-<< parameters.cache_key >>-cache-key
-            - restore_owasp_cache:
-                cache_key: << parameters.cache_key >>
-            - run:
-                name: Update OWASP Dependency-Check Database
-                command: mvn org.owasp:dependency-check-maven:update-only
-            - store_owasp_cache:
-                cve_data_directory: <<parameters.cve_data_directory>>
-                cache_key: << parameters.cache_key >>
             - run:
                 name: Run OWASP Dependency-Check Analyzer
                 command: mvn org.owasp:dependency-check-maven:<<parameters.task>>
-            - run:
-                # note: Also run purge so so that vulernability data is not cached twice.
-                # Run in seperate step so not run for each submodule.
-                name: OWASP Dependency-Check cache cleanup
-                command: mvn org.owasp:dependency-check-maven:purge
-            - collect_reports:
-                persist_to_workspace: <<parameters.persist_to_workspace>>
+
   commandline_owasp_dependency_check:
     parameters:
       executor:
@@ -366,8 +448,8 @@ jobs:
           version: << parameters.version >>
           cache_key: << parameters.cache_key >>
           steps:
-            - generate_cache_keys:
-                cache_key: commmandline-<< parameters.cache_key >>-cache-key
+            - generate_cache_keys:  # time-based keys for both restore and store
+                cache_key: commmandline-<< parameters.cache_key >>-cache-key  # flow-specific key
             - restore_owasp_cache:
                 cache_key: << parameters.cache_key >>
             - run:

--- a/src/@orb.yml
+++ b/src/@orb.yml
@@ -108,7 +108,6 @@ aliases:
       - checkout
       - wrapped_gradle_steps:
           cve_data_directory: <<parameters.cve_data_directory>>
-          settings_file: <<parameters.settings_file>>
           cache_key: <<parameters.cache_key>>
           persist_to_workspace: <<parameters.persist_to_workspace>>
           steps:
@@ -236,13 +235,13 @@ commands:
       pre_steps:
         description: Pre-processing steps to run in order to prepare the dependency check. Intended for multi-module builds (which require build before dependency check)
         type: steps
+        default: []
       steps:
         type: steps
         description: Steps to run in order to perform the dependency check
     steps:
       - checkout
       - maven/with_cache:
-          cache_key: << parameters.cache_key >>
           settings_file: << parameters.settings_file >>
           verify_dependencies: false
           steps:
@@ -285,6 +284,7 @@ commands:
       pre_steps:
         description: Pre-processing steps to run in order to prepare the dependency check
         type: steps
+        default: []
       steps:
         description: Steps to run in order to perform the dependency check
         type: steps

--- a/src/@orb.yml
+++ b/src/@orb.yml
@@ -82,6 +82,8 @@ executors:
 
 aliases:
   - &gradle_owasp_dependency_check
+    description: |
+      Run OWASP dependency check for a Gradle project
     parameters:
       executor:
         description: The name of custom executor to use.
@@ -103,6 +105,12 @@ aliases:
         description: Persist reports to workspace for further processing.
         type: boolean
         default: false
+      wrapped_pre_steps:
+        description: |
+          Pre-processing steps to run in order to prepare the dependency check.
+          Not to be confused with the regular 'pre-steps' parameter, this runs after the Gradle cache has been restored and the OWASP database is updated.
+        type: steps
+        default: []
     executor: <<parameters.executor>>
     steps:
       - checkout
@@ -110,7 +118,8 @@ aliases:
           cve_data_directory: <<parameters.cve_data_directory>>
           cache_key: <<parameters.cache_key>>
           persist_to_workspace: <<parameters.persist_to_workspace>>
-          steps:
+          wrapped_pre_steps: <<parameters.wrapped_pre_steps>>
+          wrapped_steps:
             - run:
                 name: Run OWASP Dependency-Check Analyzer
                 command: ./gradlew <<parameters.task>> --info
@@ -232,11 +241,11 @@ commands:
         description: Persist reports to workspace for further processing.
         type: boolean
         default: false
-      pre_steps:
+      wrapped_pre_steps:
         description: Pre-processing steps to run in order to prepare the dependency check. Intended for multi-module builds (which require build before dependency check)
         type: steps
         default: []
-      steps:
+      wrapped_steps:
         type: steps
         description: Steps to run in order to perform the dependency check
     steps:
@@ -255,8 +264,8 @@ commands:
             - store_owasp_cache:
                 cve_data_directory: <<parameters.cve_data_directory>>
                 cache_key: << parameters.cache_key >>
-            - steps: << parameters.pre_steps >>
-            - steps: << parameters.steps >>
+            - steps: << parameters.wrapped_pre_steps >>
+            - steps: << parameters.wrapped_steps >>
             - run:
                 # note: Also run purge so so that vulernability data is not cached twice.
                 # Run in seperate step so not run for each submodule.
@@ -281,11 +290,11 @@ commands:
         description: Persist reports to workspace for further processing.
         type: boolean
         default: false
-      pre_steps:
+      wrapped_pre_steps:
         description: Pre-processing steps to run in order to prepare the dependency check
         type: steps
         default: []
-      steps:
+      wrapped_steps:
         description: Steps to run in order to perform the dependency check
         type: steps
     steps:
@@ -303,8 +312,8 @@ commands:
             - store_owasp_cache:
                 cve_data_directory: <<parameters.cve_data_directory>>
                 cache_key: << parameters.cache_key >>
-            - steps: << parameters.pre_steps >>
-            - steps: << parameters.steps >>
+            - steps: << parameters.wrapped_pre_steps >>
+            - steps: << parameters.wrapped_steps >>
             - run:
                 # note: Also run purge so so that vulernability data is not cached twice.
                 # Run in seperate step so not run for each submodule.
@@ -374,6 +383,8 @@ jobs:
   owasp_dependency_check: *gradle_owasp_dependency_check  # default to gradle
   gradle_owasp_dependency_check: *gradle_owasp_dependency_check
   maven_owasp_dependency_check:
+    description: |
+      Run OWASP dependency check for a Maven project
     parameters:
       executor:
         description: The name of custom executor to use.
@@ -399,6 +410,12 @@ jobs:
         description: Persist reports to workspace for further processing.
         type: boolean
         default: false
+      wrapped_pre_steps:
+        description: |
+          Pre-processing steps to run in order to prepare the dependency check.
+          Not to be confused with the regular 'pre-steps' parameter, this runs after the Maven cache has been restored and the OWASP database is updated.
+        type: steps
+        default: []
     executor: <<parameters.executor>>
     steps:
       - checkout
@@ -407,7 +424,8 @@ jobs:
           settings_file: <<parameters.settings_file>>
           cache_key: <<parameters.cache_key>>
           persist_to_workspace: <<parameters.persist_to_workspace>>
-          steps:
+          wrapped_pre_steps: <<parameters.wrapped_pre_steps>>
+          wrapped_steps:
             - run:
                 name: Run OWASP Dependency-Check Analyzer
                 command: mvn org.owasp:dependency-check-maven:<<parameters.task>>

--- a/src/@orb.yml
+++ b/src/@orb.yml
@@ -423,6 +423,7 @@ jobs:
         description: |
           Pre-processing steps to run in order to prepare the dependency check.
           Not to be confused with the regular 'pre-steps' parameter, this runs after the Maven cache has been restored and the OWASP database is updated.
+          Multi-module projects might consider running the command "mvn clean install -Dmaven.test.skip=true" so that the dependency-check plugin can resolve all artifacts.
         type: steps
         default: []
     executor: <<parameters.executor>>


### PR DESCRIPTION
Add flexibility in that logic previously within jobs is moved to commands.

Add support for building maven projects (wrapped pre steps) before running the check. This solves checking projects with multiple modules.